### PR TITLE
docs: Add link to pull request template

### DIFF
--- a/org/git-onboarding-guide.md
+++ b/org/git-onboarding-guide.md
@@ -145,7 +145,7 @@ Follow these steps for each task or feature you work on:
    - Go to the repository on GitHub
    - Click "Pull requests" > "New pull request"
    - Select your branch
-   - Fill in the PR template
+   - Fill in the [PR template](../.github/pull_request_template.md)
    - Assign reviewers and add labels
 
 7. **Address Review Comments**
@@ -239,7 +239,7 @@ If you encounter merge conflicts:
 
 ## 5. Pull Requests
 
-- Use the PR template provided in the repository
+- Use the [PR template](../.github/pull_request_template.md) provided in the repository
 - Link the relevant issue(s) in the PR description
 - Ensure all CI checks pass before requesting review
 


### PR DESCRIPTION
## Description
Opening a discussion: Students who are not yet familiar with conventions won't know to look in the .github folder to see the structure of the template. This adds a docs link so that they can see it in advance.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
N/A

## Checklist:
N/A

## Related Issue(s)
N/A